### PR TITLE
update constrstarts-fastai image

### DIFF
--- a/constrstarts-fastai/Dockerfile
+++ b/constrstarts-fastai/Dockerfile
@@ -2,6 +2,10 @@
 # GPU, ubuntu16.04
 FROM paperspace/fastai:1.0-CUDA9.2-base-3.0-v1.0.6
 
+# RUN apt-get update && apt-get install htop \
+#            && apt-get clean \ 
+#            && rm -rf /var/lib/apt/lists/*
+
 ENV NB_PREFIX /
 ENV PATH=$PATH:/opt/conda/bin
 ENV USER fastai
@@ -14,7 +18,6 @@ COPY requirements.txt install_requirements.sh /home/jovyan/
 # removal due to security risk
 RUN apt-get remove -y libxml2
 RUN rm -rf /notebooks
-
 
 # "shell" form
 CMD ./install_requirements.sh ; /opt/conda/envs/fastai/bin/jupyter notebook --notebook-dir=/home/jovyan --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=${NB_PREFIX}

--- a/constrstarts-fastai/requirements.txt
+++ b/constrstarts-fastai/requirements.txt
@@ -2,8 +2,10 @@ descartes==1.1.0
 rio-tiler==1.4.0
 gpustat==0.6.0
 mlflow==1.6.0
-fastai==1.0.58
+fastai==1.0.42
 pigeon-jupyter==0.1.0
 opencv-python==4.2.0.34
 distro==1.4.0
 scikit-image==0.16.2
+gpustat==0.6.0
+jupyterlab==2.1.5


### PR DESCRIPTION
Update of project image:

- set correct fastai version
- added gpustat install for gpu monitoring
- added jupyterlab, as I expect only Jupyterlab to continue run notebooks when browser disconnection occurs. Hence this is crucial for our deep learning training. /cc @blairdrummond 